### PR TITLE
Add conda-forge version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ immutables
 
 .. image:: https://img.shields.io/pypi/v/immutables.svg
     :target: https://pypi.python.org/pypi/immutables
+    
+.. image:: https://img.shields.io/conda/vn/conda-forge/immutables.svg
+    :target: https://anaconda.org/conda-forge/immutables    
 
 An immutable mapping type for Python.
 


### PR DESCRIPTION
Hi!

This adds a badge with the version of the conda package for `immutables` at `conda-forge`. This makes it clear that conda users can install `immutables`. 👍 

Thanks for all the work!