### PR TITLE
fix: add package_data to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
     url='https://github.com/MagicStack/immutables',
     license='Apache License, Version 2.0',
     packages=['immutables'],
+    package_data={"immutables": ["py.typed", "*.pyi"]},
     provides=['immutables'],
     include_package_data=True,
     ext_modules=ext_modules,


### PR DESCRIPTION
I forgot to add `package_data` to setup.py, so the stubs aren't shipped with 0.10. I have verified locally that this works with mypy.