### PR TITLE
Fix errors when a kwarg is named "col"

### DIFF
--- a/immutables/map.py
+++ b/immutables/map.py
@@ -433,7 +433,16 @@ class MapItems:
 
 class Map:
 
-    def __init__(self, col=None, **kw):
+    def __init__(self, *args, **kw):
+        if not args:
+            col = None
+        elif len(args) == 1:
+            col = args[0]
+        else:
+            raise TypeError(
+                "Map expected at most 1 argument, got {}".format(len(args))
+            )
+
         self.__count = 0
         self.__root = BitmapNode(0, 0, [], 0)
         self.__hash = -1
@@ -483,8 +492,18 @@ class Map:
 
         return True
 
-    def update(self, col=None, **kw):
+    def update(self, *args, **kw):
+        if not args:
+            col = None
+        elif len(args) == 1:
+            col = args[0]
+        else:
+            raise TypeError(
+                "update expected at most 1 argument, got {}".format(len(args))
+            )
+
         it = None
+
         if col is not None:
             if hasattr(col, 'items'):
                 it = iter(col.items())
@@ -721,7 +740,16 @@ class MapMutation:
         else:
             return True
 
-    def update(self, col=None, **kw):
+    def update(self, *args, **kw):
+        if not args:
+            col = None
+        elif len(args) == 1:
+            col = args[0]
+        else:
+            raise TypeError(
+                "update expected at most 1 argument, got {}".format(len(args))
+            )
+
         if self.__mutid == 0:
             raise ValueError('mutation {!r} has been finished'.format(self))
 

--- a/immutables/map.py
+++ b/immutables/map.py
@@ -440,7 +440,8 @@ class Map:
             col = args[0]
         else:
             raise TypeError(
-                "immutables.Map expected at most 1 arguments, got {}".format(len(args))
+                "immutables.Map expected at most 1 arguments, "
+                "got {}".format(len(args))
             )
 
         self.__count = 0

--- a/immutables/map.py
+++ b/immutables/map.py
@@ -440,7 +440,7 @@ class Map:
             col = args[0]
         else:
             raise TypeError(
-                "Map expected at most 1 argument, got {}".format(len(args))
+                "immutables.Map expected at most 1 arguments, got {}".format(len(args))
             )
 
         self.__count = 0
@@ -499,7 +499,7 @@ class Map:
             col = args[0]
         else:
             raise TypeError(
-                "update expected at most 1 argument, got {}".format(len(args))
+                "update expected at most 1 arguments, got {}".format(len(args))
             )
 
         it = None
@@ -747,7 +747,7 @@ class MapMutation:
             col = args[0]
         else:
             raise TypeError(
-                "update expected at most 1 argument, got {}".format(len(args))
+                "update expected at most 1 arguments, got {}".format(len(args))
             )
 
         if self.__mutid == 0:

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1436,20 +1436,15 @@ class BaseMapTest:
     def test_map_is_subscriptable(self):
         self.assertIs(self.Map[int, str], self.Map)
 
-
-class PyMapTest(BaseMapTest, unittest.TestCase):
-
-    Map = PyMap
-
-    # TODO:
-    #   1. Make `test_kwarg_named_col` test pass.
-    #   2. Remove `test_kwarg_named_col` from `PyMapTest` and `CMapTest`.
-    #      Move it to `BaseMapTest`.
-    @unittest.expectedFailure
     def test_kwarg_named_col(self):
         self.assertEqual(dict(self.Map(col=0)), {"col": 0})
         self.assertEqual(dict(self.Map(a=0, col=1)), {"a": 0, "col": 1})
         self.assertEqual(dict(self.Map({"a": 0}, col=1)), {"a": 0, "col": 1})
+
+
+class PyMapTest(BaseMapTest, unittest.TestCase):
+
+    Map = PyMap
 
 
 try:
@@ -1462,11 +1457,6 @@ except ImportError:
 class CMapTest(BaseMapTest, unittest.TestCase):
 
     Map = CMap
-
-    def test_kwarg_named_col(self):
-        self.assertEqual(dict(self.Map(col=0)), {"col": 0})
-        self.assertEqual(dict(self.Map(a=0, col=1)), {"a": 0, "col": 1})
-        self.assertEqual(dict(self.Map({"a": 0}, col=1)), {"a": 0, "col": 1})
 
 
 if __name__ == "__main__":

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1441,6 +1441,16 @@ class PyMapTest(BaseMapTest, unittest.TestCase):
 
     Map = PyMap
 
+    # TODO:
+    #   1. Make `test_kwarg_named_col` test pass.
+    #   2. Remove `test_kwarg_named_col` from `PyMapTest` and `CMapTest`.
+    #      Move it to `BaseMapTest`.
+    @unittest.expectedFailure
+    def test_kwarg_named_col(self):
+        self.assertEqual(dict(self.Map(col=0)), {"col": 0})
+        self.assertEqual(dict(self.Map(a=0, col=1)), {"a": 0, "col": 1})
+        self.assertEqual(dict(self.Map({"a": 0}, col=1)), {"a": 0, "col": 1})
+
 
 try:
     from immutables._map import Map as CMap
@@ -1452,6 +1462,11 @@ except ImportError:
 class CMapTest(BaseMapTest, unittest.TestCase):
 
     Map = CMap
+
+    def test_kwarg_named_col(self):
+        self.assertEqual(dict(self.Map(col=0)), {"col": 0})
+        self.assertEqual(dict(self.Map(a=0, col=1)), {"a": 0, "col": 1})
+        self.assertEqual(dict(self.Map({"a": 0}, col=1)), {"a": 0, "col": 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Background
It seems there is an inconsistency in how the Python and C implementations handle a `Map.__init__`, `Mapy.update`, or `MapMutation.update` keyword argument that is named "col". The C implementation works similarly to the builtin `dict` init. Python implementation seems to have some issues though.

## Changes in this PR
- Remove the special role of a kwarg called "col" from kwargs of `Map.__init__`, `Map.update` and `MapMutation.update`. Assume that if there is a positional arg, it must be a collection, do not care about the name "col".