### PR TITLE
Make __repr__ more similar to other mapping types

### DIFF
--- a/immutables/_map.c
+++ b/immutables/_map.c
@@ -3194,14 +3194,14 @@ map_py_repr(BaseMapObject *m)
 
     if (MapMutation_Check(m)) {
         if (_PyUnicodeWriter_WriteASCIIString(
-                &writer, "MapMutation({", 13) < 0)
+                &writer, "immutables.MapMutation({", 24) < 0)
         {
             goto error;
         }
     }
     else {
         if (_PyUnicodeWriter_WriteASCIIString(
-                &writer, "Map({", 5) < 0)
+                &writer, "immutables.Map({", 16) < 0)
         {
             goto error;
         }

--- a/immutables/_map.c
+++ b/immutables/_map.c
@@ -3194,14 +3194,14 @@ map_py_repr(BaseMapObject *m)
 
     if (MapMutation_Check(m)) {
         if (_PyUnicodeWriter_WriteASCIIString(
-                &writer, "<immutables.MapMutation({", 25) < 0)
+                &writer, "MapMutation({", 13) < 0)
         {
             goto error;
         }
     }
     else {
         if (_PyUnicodeWriter_WriteASCIIString(
-                &writer, "<immutables.Map({", 17) < 0)
+                &writer, "Map({", 5) < 0)
         {
             goto error;
         }
@@ -3254,16 +3254,6 @@ map_py_repr(BaseMapObject *m)
     if (_PyUnicodeWriter_WriteASCIIString(&writer, "})", 2) < 0) {
         goto error;
     }
-
-    PyObject *addr = PyUnicode_FromFormat(" at %p>", m);
-    if (addr == NULL) {
-        goto error;
-    }
-    if (_PyUnicodeWriter_WriteStr(&writer, addr) < 0) {
-        Py_DECREF(addr);
-        goto error;
-    }
-    Py_DECREF(addr);
 
     Py_ReprLeave((PyObject *)m);
     return _PyUnicodeWriter_Finish(&writer);

--- a/immutables/map.py
+++ b/immutables/map.py
@@ -649,7 +649,7 @@ class Map:
         items = []
         for key, val in self.items():
             items.append("{!r}: {!r}".format(key, val))
-        return 'Map({{{}}})'.format(', '.join(items))
+        return 'immutables.Map({{{}}})'.format(', '.join(items))
 
     def __dump__(self):  # pragma: no cover
         buf = []
@@ -817,7 +817,7 @@ class MapMutation:
         items = []
         for key, val in self.__root.items():
             items.append("{!r}: {!r}".format(key, val))
-        return 'MapMutation({{{}}})'.format(', '.join(items))
+        return 'immutables.MapMutation({{{}}})'.format(', '.join(items))
 
     def __len__(self):
         return self.__count

--- a/immutables/map.py
+++ b/immutables/map.py
@@ -649,8 +649,7 @@ class Map:
         items = []
         for key, val in self.items():
             items.append("{!r}: {!r}".format(key, val))
-        return '<immutables.Map({{{}}}) at 0x{:0x}>'.format(
-            ', '.join(items), id(self))
+        return 'Map({{{}}})'.format(', '.join(items))
 
     def __dump__(self):  # pragma: no cover
         buf = []
@@ -818,8 +817,7 @@ class MapMutation:
         items = []
         for key, val in self.__root.items():
             items.append("{!r}: {!r}".format(key, val))
-        return '<immutables.MapMutation({{{}}}) at 0x{:0x}>'.format(
-            ', '.join(items), id(self))
+        return 'MapMutation({{{}}})'.format(', '.join(items))
 
     def __len__(self):
         return self.__count

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -845,11 +845,10 @@ class BaseMapTest:
 
     def test_repr_1(self):
         h = self.Map()
-        self.assertTrue(repr(h).startswith('<immutables.Map({}) at 0x'))
+        self.assertEqual(repr(h), 'Map({})')
 
         h = h.set(1, 2).set(2, 3).set(3, 4)
-        self.assertTrue(repr(h).startswith(
-            '<immutables.Map({1: 2, 2: 3, 3: 4}) at 0x'))
+        self.assertEqual(repr(h), 'Map({1: 2, 2: 3, 3: 4})')
 
     def test_repr_2(self):
         h = self.Map()
@@ -879,8 +878,7 @@ class BaseMapTest:
         h = h.set(k, 1)
         k.val = h
 
-        self.assertTrue(repr(h).startswith(
-            '<immutables.Map({{...}: 1}) at 0x'))
+        self.assertEqual(repr(h), 'Map({{...}: 1})')
 
     def test_hash_1(self):
         h = self.Map()
@@ -964,8 +962,7 @@ class BaseMapTest:
         h = h.set('a', 1)
         hm1 = h.mutate()
 
-        self.assertTrue(repr(hm1).startswith(
-            "<immutables.MapMutation({'a': 1})"))
+        self.assertEqual(repr(hm1), "MapMutation({'a': 1})")
 
         with self.assertRaisesRegex(TypeError, 'unhashable type'):
             hash(hm1)

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -845,10 +845,10 @@ class BaseMapTest:
 
     def test_repr_1(self):
         h = self.Map()
-        self.assertEqual(repr(h), 'Map({})')
+        self.assertEqual(repr(h), 'immutables.Map({})')
 
         h = h.set(1, 2).set(2, 3).set(3, 4)
-        self.assertEqual(repr(h), 'Map({1: 2, 2: 3, 3: 4})')
+        self.assertEqual(repr(h), 'immutables.Map({1: 2, 2: 3, 3: 4})')
 
     def test_repr_2(self):
         h = self.Map()
@@ -878,7 +878,7 @@ class BaseMapTest:
         h = h.set(k, 1)
         k.val = h
 
-        self.assertEqual(repr(h), 'Map({{...}: 1})')
+        self.assertEqual(repr(h), 'immutables.Map({{...}: 1})')
 
     def test_hash_1(self):
         h = self.Map()
@@ -962,7 +962,7 @@ class BaseMapTest:
         h = h.set('a', 1)
         hm1 = h.mutate()
 
-        self.assertEqual(repr(hm1), "MapMutation({'a': 1})")
+        self.assertEqual(repr(hm1), "immutables.MapMutation({'a': 1})")
 
         with self.assertRaisesRegex(TypeError, 'unhashable type'):
             hash(hm1)

--- a/tests/test_none_keys.py
+++ b/tests/test_none_keys.py
@@ -61,7 +61,7 @@ class BaseNoneTest:
         self.assertEqual(len(m), 1)
         self.assertTrue(None in m)
         self.assertEqual(m[None], 1)
-        self.assertTrue(repr(m).startswith('<immutables.Map({None: 1}) at 0x'))
+        self.assertEqual(repr(m), 'Map({None: 1})')
 
         for level in range(7):
             key = NoneCollision('a', level)
@@ -72,7 +72,7 @@ class BaseNoneTest:
         m = m.delete(None)
         self.assertEqual(len(m), 0)
         self.assertFalse(None in m)
-        self.assertTrue(repr(m).startswith('<immutables.Map({}) at 0x'))
+        self.assertEqual(repr(m), 'Map({})')
 
         self.assertEqual(m, self.Map())
 
@@ -125,7 +125,7 @@ class BaseNoneTest:
             self.assertFalse(None in m3)
             self.assertFalse(key in m3)
             self.assertEqual(m3, self.Map())
-            self.assertTrue(repr(m3).startswith('<immutables.Map({}) at 0x'))
+            self.assertEqual(repr(m3), 'Map({})')
             with self.assertRaises(KeyError):
                 m3.delete(None)
             with self.assertRaises(KeyError):
@@ -144,7 +144,7 @@ class BaseNoneTest:
             self.assertFalse(None in m4)
             self.assertFalse(key in m4)
             self.assertEqual(m4, self.Map())
-            self.assertTrue(repr(m4).startswith('<immutables.Map({}) at 0x'))
+            self.assertEqual(repr(m4), 'Map({})')
             with self.assertRaises(KeyError):
                 m4.delete(None)
             with self.assertRaises(KeyError):

--- a/tests/test_none_keys.py
+++ b/tests/test_none_keys.py
@@ -61,7 +61,7 @@ class BaseNoneTest:
         self.assertEqual(len(m), 1)
         self.assertTrue(None in m)
         self.assertEqual(m[None], 1)
-        self.assertEqual(repr(m), 'Map({None: 1})')
+        self.assertEqual(repr(m), 'immutables.Map({None: 1})')
 
         for level in range(7):
             key = NoneCollision('a', level)
@@ -72,7 +72,7 @@ class BaseNoneTest:
         m = m.delete(None)
         self.assertEqual(len(m), 0)
         self.assertFalse(None in m)
-        self.assertEqual(repr(m), 'Map({})')
+        self.assertEqual(repr(m), 'immutables.Map({})')
 
         self.assertEqual(m, self.Map())
 
@@ -125,7 +125,7 @@ class BaseNoneTest:
             self.assertFalse(None in m3)
             self.assertFalse(key in m3)
             self.assertEqual(m3, self.Map())
-            self.assertEqual(repr(m3), 'Map({})')
+            self.assertEqual(repr(m3), 'immutables.Map({})')
             with self.assertRaises(KeyError):
                 m3.delete(None)
             with self.assertRaises(KeyError):
@@ -144,7 +144,7 @@ class BaseNoneTest:
             self.assertFalse(None in m4)
             self.assertFalse(key in m4)
             self.assertEqual(m4, self.Map())
-            self.assertEqual(repr(m4), 'Map({})')
+            self.assertEqual(repr(m4), 'immutables.Map({})')
             with self.assertRaises(KeyError):
                 m4.delete(None)
             with self.assertRaises(KeyError):


### PR DESCRIPTION
Resolves #17 

```pycon
Python 3.8.1 (tags/v3.8.1:1b293b6, Dec 18 2019, 23:11:46) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import ChainMap, OrderedDict, defaultdict
>>>
>>> d = {'one': 1, 'two': 2}
>>> d
{'one': 1, 'two': 2}
>>> ChainMap({'one': 1}, {'two': 2})
ChainMap({'one': 1}, {'two': 2})
>>> OrderedDict((('one', 1), ('two', 2)))
OrderedDict([('one', 1), ('two', 2)])
>>> dd = defaultdict(int)
>>> dd.update(d)
>>> dd
defaultdict(<class 'int'>, {'one': 1, 'two': 2})
```