### PR TITLE
Remove deprecated setup.py test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,4 +50,4 @@ jobs:
       if: steps.release.outputs.version == 0
       run: |
         pip install -e .
-        python setup.py test
+        python -m unittest -v tests.suite

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ debug:
 	DEBUG_IMMUTABLES=1 $(PYTHON) setup.py build_ext --inplace
 
 test:
-	$(PYTHON) setup.py test -v
+	$(PYTHON) -m unittest -v
 
 rtest:
 	~/dev/venvs/36-debug/bin/python setup.py build_ext --inplace

--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,4 @@ setuptools.setup(
     provides=['immutables'],
     include_package_data=True,
     ext_modules=ext_modules,
-    test_suite='tests.suite',
 )


### PR DESCRIPTION
Refs pypa/setuptools#1684, `setup.py test` is deprecated since [setuptools v41.5.0](https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0).