### PR TITLE
Fix test_none_collisions on 32-bit systems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,13 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-beta.4]
         os: [windows-latest, ubuntu-latest, macos-latest]
+        arch: [x64, x86]
+        exclude:
+          # 32-bit Python is only available on Windows
+          - os: ubuntu-latest
+            arch: x86
+          - os: macos-latest
+            arch: x86
 
     steps:
     - uses: actions/checkout@v2
@@ -38,11 +45,12 @@ jobs:
       if: steps.release.outputs.version == 0
       with:
         python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.arch }}
 
     - name: Test
       if: steps.release.outputs.version == 0
       run: |
-        pip install -e .[test]
+        pip install --verbose -e .[test]
         flake8 immutables/ tests/
         mypy immutables/
         python -m pytest -v

--- a/immutables/map.py
+++ b/immutables/map.py
@@ -19,7 +19,10 @@ _mut_id = itertools.count(1).__next__
 
 def map_hash(o):
     x = hash(o)
-    return (x & 0xffffffff) ^ ((x >> 32) & 0xffffffff)
+    if sys.hash_info.width > 32:
+        return (x & 0xffffffff) ^ ((x >> 32) & 0xffffffff)
+    else:
+        return x
 
 
 def map_mask(hash, shift):


### PR DESCRIPTION
There are two issues at play here:

1. Python version of `map_hash` unnecessarily performs hash truncation
   even if the hash is already 32-bit wide, which potentially converts
   it from signed int to unsigned long.

2. The `test_none_collisions` test generates a collision node with
   hash greater than 2^32.

Both of these are problematic on 32-bit systems, where `sizeof(Py_hash_t)`
is 4, and so anything that doesn't fit into `Py_hash_t` gets bit-mangled,
breaking the `hash(x) != x` invariance that the test relies upon.

Fixes: #53
Fixes: #50