### PR TITLE
immutables v0.16

### DIFF
--- a/immutables/_version.py
+++ b/immutables/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.15'
+__version__ = '0.16'


### PR DESCRIPTION
Updates
=======

* Refactor typings
  (by @bryanforbes in 39f9f0de and @msullivan in 4a175499)

* Update Python 3.10 support, drop Python 3.5
  (by @elprans in fa355239 and 189b959d)

Fixes
=====

* Fix `test_none_collisions` on 32-bit systems (#69)
  (by @elprans in fa355239 for #69)

Misc
====

* Clarify the license of the included `pythoncapi_compat.h` header
  (by @elprans in 67c5edfb for #64)

* Use cibuildwheel to build wheels (#70)
  (by @elprans in f671cb4d for #70)