### PR TITLE
Iteration Bug fix:

### DIFF
--- a/immutables/_map.h
+++ b/immutables/_map.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include "Python.h"
 
-#define _Py_HAMT_MAX_TREE_DEPTH 7
+#define _Py_HAMT_MAX_TREE_DEPTH 8
 
 
 #define Map_Check(o) (Py_TYPE(o) == &_Map_Type)


### PR DESCRIPTION
Assumption that there are max number of levels 7 is wrong, a collision at the 7 level creates a collision node in the 8th level, this causes iteration to stop prematurely.

for reproduction (before the fix):
PYTHONHASHSEED=0 python <<EOF
import itertools
import immutables
import random
seed=b"b\xe6\xe2\x82\xe5\xc1e|"
r = random.Random(seed)
a = immutables.Map(
    zip(
        (r.randrange(0, 10000000000) for i in range(820000)),
        itertools.repeat(None, 820000),
    )
)
len1 = len(a)
len2 = len(tuple(a))
if len1 != len2:
    print(f"BADDDD seed:{seed} len(a)={len1} len(tuple(a))={len2}")
    
    
EOF
