### PR TITLE
Add PEP 585 (__class_getitem__ -> GenericAlias) support

### DIFF
--- a/immutables/_map.c
+++ b/immutables/_map.c
@@ -3359,13 +3359,6 @@ map_reduce(MapObject *self)
     return tup;
 }
 
-static PyObject *
-map_py_class_getitem(PyObject *type, PyObject *item)
-{
-    Py_INCREF(type);
-    return type;
-}
-
 static PyMethodDef Map_methods[] = {
     {"set", (PyCFunction)map_py_set, METH_VARARGS, NULL},
     {"get", (PyCFunction)map_py_get, METH_VARARGS, NULL},
@@ -3379,9 +3372,9 @@ static PyMethodDef Map_methods[] = {
     {"__dump__", (PyCFunction)map_py_dump, METH_NOARGS, NULL},
     {
         "__class_getitem__",
-        (PyCFunction)map_py_class_getitem,
+        Py_GenericAlias,
         METH_O|METH_CLASS,
-        NULL
+        "See PEP 585"
     },
     {NULL, NULL}
 };

--- a/immutables/pythoncapi_compat.h
+++ b/immutables/pythoncapi_compat.h
@@ -406,6 +406,17 @@ PyFloat_Unpack2(const char *p, int le)
 #endif
 
 
+// bpo-39481 added Py_GenericAlias to Python 3.9.0a6.
+#if PY_VERSION_HEX < 0x030900A6 && !defined(Py_GenericAlias)
+PYCAPI_COMPAT_STATIC_INLINE(PyObject *)
+Py_GenericAlias(PyObject *type, PyObject *item)
+{
+    Py_INCREF(type);
+    return type;
+}
+#endif
+
+
 // bpo-46906 added PyFloat_Pack4(), PyFloat_Pack8(), PyFloat_Unpack4() and
 // PyFloat_Unpack8() to Python 3.11a7.
 // Python 3.11a2 moved _PyFloat_Pack4(), _PyFloat_Pack8(), _PyFloat_Unpack4()


### PR DESCRIPTION
This commit add supports for PEP 585 on Python 3.9+.

This is useful for runtime introspection ( resolves #83 ).

For example, on Python 3.9+:
```python
>>> immutables.Map[str, int]
immutables._map.Map[int, str]
```

On Python 3.8-:
```python
>>> immutables.Map[str, int]
<class 'immutables.map.Map'>
```

This does not affect type checkers, as they do not utilize runtime introspection.

This is immediately useful for applications that would like to use type information for (de)serialization. Examples:
- https://github.com/python-attrs/cattrs
- https://github.com/konradhalas/dacite

Thank you for your work on this library (and PEP, to boot!).