### PR TITLE
Fix for Python 3.12 support

### DIFF
--- a/immutables/_map.c
+++ b/immutables/_map.c
@@ -529,7 +529,7 @@ _map_dump_format(_PyUnicodeWriter *writer, const char *format, ...)
     int ret;
 
     va_list vargs;
-#ifdef HAVE_STDARG_PROTOTYPES
+#if defined(HAVE_STDARG_PROTOTYPES) || PY_VERSION_HEX >= 0x030C0000
     va_start(vargs, format);
 #else
     va_start(vargs);


### PR DESCRIPTION
The `HAVE_STDARG_PROTOTYPES` macro was removed in Python 3.12 [1,2] and `va_start` with two arguments is always expected. Therefore, Python version is newly checked as well and `va_start` with 2 arguments is selected for python version greater or equal to 3.12.

[1] https://github.com/python/cpython/commit/cb04a09d2dfd197436a11de504b92773569e19fb
[2] https://github.com/python/cpython/issues/93207