### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,23 +72,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         cibw_arch: ["auto64", "aarch64", "universal2"]
         cibw_python:
-          - "cp36-*"
-          - "cp37-*"
           - "cp38-*"
           - "cp39-*"
           - "cp310-*"
           - "cp311-*"
+          - "cp312-*"
         exclude:
           - os: ubuntu-latest
             cibw_arch: universal2
           - os: macos-latest
             cibw_arch: aarch64
-          - os: macos-latest
-            cibw_python: "cp36-*"
-            cibw_arch: universal2
-          - os: macos-latest
-            cibw_python: "cp37-*"
-            cibw_arch: universal2
           - os: windows-latest
             cibw_arch: universal2
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-beta.4"]
         os: [windows-latest, ubuntu-latest, macos-latest]
         arch: [x64, x86]
         exclude:

--- a/immutables/_map.c
+++ b/immutables/_map.c
@@ -529,10 +529,10 @@ _map_dump_format(_PyUnicodeWriter *writer, const char *format, ...)
     int ret;
 
     va_list vargs;
-#ifdef HAVE_STDARG_PROTOTYPES
-    va_start(vargs, format);
-#else
+#if PY_VERSION_HEX < 0x030C00A1 && !defined(HAVE_STDARG_PROTOTYPES)
     va_start(vargs);
+#else
+    va_start(vargs, format);
 #endif
     msg = PyUnicode_FromFormatV(format, vargs);
     va_end(vargs);
@@ -1247,7 +1247,7 @@ map_node_bitmap_dealloc(MapNode_Bitmap *self)
     Py_ssize_t i;
 
     PyObject_GC_UnTrack(self);
-    Py_TRASHCAN_SAFE_BEGIN(self)
+    Py_TRASHCAN_BEGIN(self, map_node_bitmap_dealloc)
 
     if (len > 0) {
         i = len;
@@ -1257,7 +1257,7 @@ map_node_bitmap_dealloc(MapNode_Bitmap *self)
     }
 
     Py_TYPE(self)->tp_free((PyObject *)self);
-    Py_TRASHCAN_SAFE_END(self)
+    Py_TRASHCAN_END
 }
 
 static int
@@ -1664,7 +1664,7 @@ map_node_collision_dealloc(MapNode_Collision *self)
     Py_ssize_t len = Py_SIZE(self);
 
     PyObject_GC_UnTrack(self);
-    Py_TRASHCAN_SAFE_BEGIN(self)
+    Py_TRASHCAN_BEGIN(self, map_node_collision_dealloc)
 
     if (len > 0) {
 
@@ -1674,7 +1674,7 @@ map_node_collision_dealloc(MapNode_Collision *self)
     }
 
     Py_TYPE(self)->tp_free((PyObject *)self);
-    Py_TRASHCAN_SAFE_END(self)
+    Py_TRASHCAN_END
 }
 
 static int
@@ -2083,14 +2083,14 @@ map_node_array_dealloc(MapNode_Array *self)
     Py_ssize_t i;
 
     PyObject_GC_UnTrack(self);
-    Py_TRASHCAN_SAFE_BEGIN(self)
+    Py_TRASHCAN_BEGIN(self, map_node_array_dealloc)
 
     for (i = 0; i < HAMT_ARRAY_NODE_SIZE; i++) {
         Py_XDECREF(self->a_array[i]);
     }
 
     Py_TYPE(self)->tp_free((PyObject *)self);
-    Py_TRASHCAN_SAFE_END(self)
+    Py_TRASHCAN_END
 }
 
 static int

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ TEST_DEPENDENCIES = [
     # pycodestyle is a dependency of flake8, but it must be frozen because
     # their combination breaks too often
     # (example breakage: https://gitlab.com/pycqa/flake8/issues/427)
-    'flake8~=5.0.4',
-    'pycodestyle~=2.9.1',
-    'mypy==0.971',
-    'pytest~=6.2.4',
+    'flake8~=5.0',
+    'pycodestyle~=2.9',
+    'mypy~=1.4',
+    'pytest~=7.4',
 ]
 
 EXTRA_DEPENDENCIES = {
@@ -65,16 +65,16 @@ setuptools.setup(
     version=VERSION,
     description='Immutable Collections',
     long_description=readme,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: POSIX',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
Also, drop 3.6 and 3.7 as unsupported.

Fixes: #104
Closes: #97
Closes: #100
Closes: #103