### PR TITLE
Fix indentation in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,10 @@ CFLAGS = ['-O2']
 if system == 'AIX':
     CFLAGS.extend(['-qlanglvl=stdc99', '-qchars'])
 elif system == 'SUNOS':
-    CFLAGS.extend(['-xc99']) # -xchar=s is the default
+    CFLAGS.extend(['-xc99'])  # -xchar=s is the default
 elif system != 'Windows':
-     CFLAGS.extend(['-std=c99', '-fsigned-char', '-Wall',
-                    '-Wsign-compare', '-Wconversion'])
+    CFLAGS.extend(['-std=c99', '-fsigned-char', '-Wall',
+                   '-Wsign-compare', '-Wconversion'])
 
 
 with open(os.path.join(


### PR DESCRIPTION
Fixes flake8 complaints:

```
./setup.py:27:29: E261 at least two spaces before inline comment
./setup.py:29:6: E111 indentation is not a multiple of 4
./setup.py:29:6: E117 over-indented
```