### PR TITLE
Support disabling C extensions via `IMMUTABLES_EXT=0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ with open(os.path.join(
             'unable to read the version from immutables/_version.py')
 
 
-if platform.python_implementation() == 'CPython':
+if (platform.python_implementation() == 'CPython' and
+        os.environ.get('IMMUTABLES_EXT', '1') == '1'):
     if os.environ.get("DEBUG_IMMUTABLES") == '1':
         define_macros = []
         undef_macros = ['NDEBUG']


### PR DESCRIPTION
Support using `IMMUTABLES_EXT` environment variable to control whether the C extension is built explicitly.  When set to a value other than 1, the extension built is disabled.  This is helpful e.g. for future Python versions where the extension does not work (this is affecting 3.13 right now, but having an explicit option is more future-proof).