### PR TITLE
Replace `_PyLong_Format` with `PyNumber_ToBase`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ jobs:
         mkdir -p dist/
         echo "${VERSION}" > dist/VERSION
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-version
         path: dist/
 
   build-sdist:
@@ -47,21 +47,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
         submodules: true
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
 
     - name: Build source distribution
       run: |
         python -m pip install -U setuptools wheel pip
         python setup.py sdist
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-sdist
         path: dist/*.tar.*
 
   build-wheels-matrix:
@@ -70,11 +70,11 @@ jobs:
     outputs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - run: pip install cibuildwheel==2.15.0
+      - run: pip install cibuildwheel==2.21.3
       - id: set-matrix
         run: |
           MATRIX_INCLUDE=$(
@@ -103,7 +103,7 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
         submodules: true
@@ -112,16 +112,16 @@ jobs:
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2
 
-    - uses: pypa/cibuildwheel@39a63b5912f086dd459cf6fcb13dcdd3fe3bc24d  # v2.15.0
+    - uses: pypa/cibuildwheel@7940a4c0e76eb2030e473a5f864f291f63ee879b  # v2.21.3
       with:
         only: ${{ matrix.only }}
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_ENVIRONMENT: "IMMU_SKIP_MYPY_TESTS=1"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-${{ matrix.only }}
         path: wheelhouse/*.whl
 
   publish:
@@ -129,14 +129,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 5
         submodules: false
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
-        name: dist
+        name: dist-*
+        merge-multiple: true
         path: dist/
 
     - name: Extract Release Version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-beta.4"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, ubuntu-latest, macos-latest]
         arch: [x64, x86]
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             arch: x86
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 50
         submodules: true
@@ -41,7 +41,7 @@ jobs:
           __version__\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       if: steps.release.outputs.version == 0
       env:
         PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,16 @@ jobs:
             arch: x86
           - os: macos-latest
             arch: x86
+          # https://github.com/actions/setup-python/issues/948
+          - os: macos-latest
+            arch: x64
+            python-version: 3.8
+          - os: macos-latest
+            arch: x64
+            python-version: 3.9
+          - os: macos-latest
+            arch: x64
+            python-version: 3.10
 
     steps:
     - uses: actions/checkout@v4

--- a/immutables/_map.c
+++ b/immutables/_map.c
@@ -1284,7 +1284,7 @@ map_node_bitmap_dump(MapNode_Bitmap *node,
     if (tmp1 == NULL) {
         goto error;
     }
-    tmp2 = _PyLong_Format(tmp1, 2);
+    tmp2 = PyNumber_ToBase(tmp1, 2);
     Py_DECREF(tmp1);
     if (tmp2 == NULL) {
         goto error;


### PR DESCRIPTION
`_PyLong_Format` is in Python’s [internal, private API](https://devguide.python.org/developer-workflow/c-api/); [`PyNumber_ToBase`](https://docs.python.org/3/c-api/number.html#c.PyNumber_ToBase) belongs to the Stable API, and is a fairly thin wrapper around `_PyLong_Format` with a bit of extra error checking.

Fixes #116.